### PR TITLE
Update to fix error in byte writing to file. 

### DIFF
--- a/Kompress/Decompress.cs
+++ b/Kompress/Decompress.cs
@@ -62,7 +62,7 @@ namespace Kompress
             string bits = null;
             string strTemp = null;
             string temp = null;
-            temp = input + 0;
+            temp = input;
             Console.WriteLine("Debug2: " + input);
             for (int i = 0; i < temp.Length; i++)
             {

--- a/Kompress/Program.cs
+++ b/Kompress/Program.cs
@@ -72,6 +72,11 @@ namespace Kompress
                 //Console.WriteLine(finalBits);
             }
             Console.WriteLine("FINAL BITS: \n" + finalBits);
+            int extra = finalBits.Length % 8;
+            for (int i = 0; i < extra; i++)
+            {
+                finalBits += 0;
+            }
             int numberofBytes = finalBits.Length / 8;
             Byte[] bytes = new Byte[numberofBytes];
             for (int i = 0; i < numberofBytes; i++)
@@ -84,10 +89,10 @@ namespace Kompress
                 ENCODED = ENCODED + (Convert.ToChar(Convert.ToInt32(bytes[i])));
             }
 
-            
+            Console.WriteLine("DEBUG: " + ENCODED);
             
 
-            File.WriteAllText("test.txt", ENCODED);
+            File.WriteAllText("test.txt", Convert.ToString(ENCODED));
 
 
             File.WriteAllText("key.txt", null);


### PR DESCRIPTION
We terminate the byte stream with 0s in order to make the proper amount of bytes. Outputs should be correct again.